### PR TITLE
perf: improve get goroutine id

### DIFF
--- a/goroutine.go
+++ b/goroutine.go
@@ -1,17 +1,17 @@
 package async
 
 import (
-	"fmt"
-	"runtime/debug"
+	"bytes"
+	"runtime"
+	"strconv"
 )
 
 // GoroutineID returns the current goroutine id.
 func GoroutineID() (uint, error) {
-	var id uint
-	var prefix string
-	_, err := fmt.Sscanf(string(debug.Stack()), "%s %d", &prefix, &id)
-	if err != nil {
-		return 0, err
-	}
-	return id, nil
+	b := make([]byte, 64)
+	b = b[:runtime.Stack(b, false)]
+	b = bytes.TrimPrefix(b, []byte("goroutine "))
+	b = b[:bytes.IndexByte(b, ' ')]
+	n, err := strconv.ParseUint(string(b), 10, 64)
+	return uint(n), err
 }

--- a/goroutine_test.go
+++ b/goroutine_test.go
@@ -1,0 +1,23 @@
+package async
+
+import (
+	"testing"
+
+	"github.com/reugn/async/internal"
+)
+
+func TestGoroutineID(t *testing.T) {
+	gid, err := GoroutineID()
+
+	internal.AssertEqual(t, nil, err)
+	t.Log(gid)
+}
+
+func BenchmarkGetGroutineID3(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := GoroutineID()
+		if err != nil {
+			b.Error("failed to get gid")
+		}
+	}
+}


### PR DESCRIPTION
### change

import goroutineID() performance.

#### test code

```
package async

import (
	"bytes"
	"fmt"
	"runtime"
	"runtime/debug"
	"strconv"
	"testing"

	"github.com/reugn/async/internal"
)

func TestGoroutineID(t *testing.T) {
	gid, err := goroutineID()
	internal.AssertEqual(t, nil, err)

	ggid, err := goroutineID2()
	internal.AssertEqual(t, nil, err)

	internal.AssertEqual(t, gid, ggid)
}

func BenchmarkGetGroutineID(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_, err := goroutineID()
		if err != nil {
			b.Error("failed to get gid")
		}
	}
}

func BenchmarkGetGroutineID2(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_, err := goroutineID2()
		if err != nil {
			b.Error("failed to get gid")
		}
	}
}

func goroutineID() (uint, error) {
	var id uint
	var prefix string
	_, err := fmt.Sscanf(string(debug.Stack()), "%s %d", &prefix, &id)
	if err != nil {
		return 0, err
	}
	return id, nil
}

func goroutineID2() (uint64, error) {
	b := make([]byte, 64)
	b = b[:runtime.Stack(b, false)]
	b = bytes.TrimPrefix(b, []byte("goroutine "))
	b = b[:bytes.IndexByte(b, ' ')]
	n, err := strconv.ParseUint(string(b), 10, 64)
	return n, err
}
```

#### test pass

```
=== RUN   TestGoroutineID
--- PASS: TestGoroutineID (0.00s)
```

#### benchmark result

```go
BenchmarkGetGroutineID
BenchmarkGetGroutineID-12     	  261309	      4575 ns/op	    1712 B/op	       8 allocs/op
BenchmarkGetGroutineID2
BenchmarkGetGroutineID2-12    	  383796	      2994 ns/op	      66 B/op	       2 allocs/op
```

